### PR TITLE
feat: create new download command connected to new endpoint

### DIFF
--- a/geoseeq/cli/utils.py
+++ b/geoseeq/cli/utils.py
@@ -1,6 +1,8 @@
 import logging
+import math
 
 import click
+
 from geoseeq.knex import DEFAULT_ENDPOINT
 
 from .. import Knex
@@ -93,3 +95,13 @@ def use_common_state(f):
 def is_uuid(name):
     chunks = name.split('-')
     return len(chunks) == 5
+
+
+def convert_size(size_bytes):
+   if size_bytes == 0:
+       return "0B"
+   size_name = ("B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB")
+   i = int(math.floor(math.log(size_bytes, 1024)))
+   p = math.pow(1024, i)
+   s = round(size_bytes / p, 2)
+   return "%s %s" % (s, size_name[i])


### PR DESCRIPTION
New download command (download files) currently just next to download sample-results. The command use the new server endpoint so generates only one request for fetching the download links and has the following new features:
- files can be filtered for a list of extensions
- group results can also be fetched with --folder-type = "all" or "project"
- Files can be downloaded with all previous versions or just the current
The generated file names have the following format:
{project_name}.{sample_name}.{folder_name}.{file_name}.{extension}   (without versions)
{project_name}.{sample_name}.{folder_name}.{file_name}.v{version_no}.{extension}.  (with versions)

All "." in entity names are replaced to "-" , "::" to "__" and invalid characters ([":", '"', "<", ">", "/", "\\", "|", "?"], maybe there are more actually...) to "-" on the server side.

Download commands will be displayed on the geoseeq FE to help users.

Question: the server currently send links in a simple dictionary where keys are the generated filenames the values are the download links (the --urls-only command downloads this dict as a json). Do we need more info? Previously the stored data of each field was possible to download. Do we need that? If yes I have to modify the server first a bit. Not too much effort if we want to. On the other hand does not really contains more info just in more structured way.