### PR TITLE
Improve test suite and CI

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -1,29 +1,21 @@
-name: Run unit Tests
+name: Run unit tests
 
 on:
-  workflow_dispatch:
-  
+  pull_request:
+  push:
+    branches: [ main ]
+
 jobs:
-  run_unit_tests:
-
-    runs-on: self-hosted
-
+  test:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          path: geoseeq_api_client
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10' 
-
-      - name: Install client
+          python-version: '3.10'
+      - name: Install dependencies
         run: |
-          export GEOSEEQ_API_TESTING_ENDPOINT=https://geoseeq.dev.biotia.io
-          cd $GITHUB_WORKSPACE/geoseeq_api_client/
-          python setup.py install
-          
-      - name: Run Unit Tests
-        run: |
-          export GEOSEEQ_API_TESTING_ENDPOINT=https://geoseeq.dev.biotia.io
-          cd $GITHUB_WORKSPACE/geoseeq_api_client/
-          python -m unittest
+          python -m pip install --upgrade pip
+          pip install -e .[test]
+      - name: Run tests
+        run: pytest -q

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -3,6 +3,7 @@ import random
 import sys
 from os import environ
 from unittest import TestCase, skip
+import pytest
 
 from geoseeq import (
     Knex,
@@ -13,7 +14,13 @@ from geoseeq import (
 from requests.exceptions import ConnectionError
 
 ENDPOINT = environ.get("GEOSEEQ_API_TESTING_ENDPOINT", "http://127.0.0.1:8000")
-TOKEN = environ.get("GEOSEEQ_API_TOKEN", "<no_token>")
+TOKEN = environ.get("GEOSEEQ_API_TOKEN")
+
+if not TOKEN:
+    pytest.skip(
+        "GeoSeeq integration tests require GEOSEEQ_API_TOKEN to be set",
+        allow_module_level=True,
+    )
 
 
 def random_str(len=12):

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import unittest
+import pytest
 from pathlib import Path
 from geoseeq.knex import Knex
 from geoseeq.organization import Organization
@@ -14,7 +15,9 @@ class TestDownload(unittest.TestCase):
         cls.test_org_name = os.getenv("GEOSEEQ_TEST_ORG", "API Client Test Organization")
         cls.test_api_token = os.getenv("GEOSEEQ_TEST_API_TOKEN")
         if not cls.test_api_token:
-            raise ValueError("GEOSEEQ_TEST_API_TOKEN environment variable must be set")
+            pytest.skip(
+                "GeoSeeq integration tests require GEOSEEQ_TEST_API_TOKEN", allow_module_level=True
+            )
 
     def setUp(self):
         # Set up test environment

--- a/tests/test_download_cli.py
+++ b/tests/test_download_cli.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import unittest
+import pytest
 from pathlib import Path
 from click.testing import CliRunner
 from geoseeq.knex import Knex
@@ -14,7 +15,9 @@ class TestDownloadCLI(unittest.TestCase):
         cls.test_org_name = os.getenv("GEOSEEQ_TEST_ORG", "API Client Test Organization")
         cls.test_api_token = os.getenv("GEOSEEQ_TEST_API_TOKEN")
         if not cls.test_api_token:
-            raise ValueError("GEOSEEQ_TEST_API_TOKEN environment variable must be set")
+            pytest.skip(
+                "GeoSeeq integration tests require GEOSEEQ_TEST_API_TOKEN", allow_module_level=True
+            )
 
     def setUp(self):
         # Set up test environment

--- a/tests/test_file_chunker.py
+++ b/tests/test_file_chunker.py
@@ -1,0 +1,18 @@
+import tempfile
+
+from geoseeq.result.file_chunker import FileChunker
+
+
+def test_file_chunker_reads_chunks_correctly():
+    data = b"abcdefghij"  # 10 bytes
+    with tempfile.NamedTemporaryFile(delete=False) as tmp:
+        tmp.write(data)
+        tmp_path = tmp.name
+    chunker = FileChunker(tmp_path, chunk_size=3)
+    assert chunker.n_parts == 4
+    # Without preloading
+    assert chunker.get_chunk(0) == b"abc"
+    assert chunker.get_chunk_size(3) == 1
+    chunker.load_all_chunks()
+    assert len(chunker.loaded_parts) == 4
+    assert chunker.get_chunk(2) == b"ghi"

--- a/tests/test_file_system_cache.py
+++ b/tests/test_file_system_cache.py
@@ -1,0 +1,19 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from geoseeq import file_system_cache
+from geoseeq.file_system_cache import FileSystemCache
+
+
+def test_cache_blob_round_trip(tmp_path, monkeypatch):
+    monkeypatch.setattr(file_system_cache, "USE_GEOSEEQ_CACHE", True)
+    monkeypatch.setattr(file_system_cache, "GEOSEEQ_CACHE_DIR", str(tmp_path))
+    cache = FileSystemCache(timeout=60)
+    obj = "object-id"
+    blob = {"a": 1}
+    cache.cache_blob(obj, blob)
+    assert cache.get_cached_blob(obj) == blob
+    cache.clear_blob(obj)
+    assert cache.get_cached_blob(obj) is None

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,29 +1,29 @@
 """Test suite for plotting library."""
-import random
-from os import environ
-from os.path import dirname, join
-from unittest import TestCase, skip
+from unittest import TestCase
 
 from geoseeq.plotting.map import Map
 
 
 class TestGeoseeqPlotting(TestCase):
-    """Test suite for packet building."""
+    """Test basic map creation."""
 
     def test_make_map_complex(self):
-        """Test that we can create a map and turn it into a dict."""
-        map = Map()\
-            .set_center(0, 0)\
-            .set_zoom(2)\
-            .add_light_base_map()\
-            .add_administrative_overlay()\
+        """Map with multiple layers converts to dict."""
+        map_obj = (
+            Map()
+            .set_center(0, 0)
+            .set_zoom(2)
+            .add_light_base_map()
+            .add_administrative_overlay()
             .add_places_overlay()
-        map.to_dict()
+        )
+        d = map_obj.to_dict()
+        self.assertIn("baseLayers", d)
+        self.assertGreaterEqual(len(d["baseLayers"]), 1)
 
     def test_make_map_simple(self):
-        """Test that we can create a map and turn it into a dict."""
-        map = Map()\
-            .add_light_base_map()
-        map.to_dict()
-        
-        
+        """Simple map converts to dict."""
+        map_obj = Map().add_light_base_map()
+        d = map_obj.to_dict()
+        self.assertIn("baseLayers", d)
+        self.assertEqual(len(d["baseLayers"]), 1)

--- a/tests/test_remote_object.py
+++ b/tests/test_remote_object.py
@@ -1,0 +1,13 @@
+from geoseeq.remote_object import RemoteObject
+
+
+class DummyRemote(RemoteObject):
+    remote_fields = []
+    parent_field = None
+
+
+def test_updated_at_timestamp():
+    obj = DummyRemote()
+    obj.updated_at = "2024-03-13T09:06:56.000000Z"
+    ts = obj.updated_at_timestamp
+    assert round(ts) == 1710320816

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import unittest
+import pytest
 from pathlib import Path
 from geoseeq.knex import Knex
 from geoseeq.organization import Organization
@@ -13,7 +14,9 @@ class TestUpload(unittest.TestCase):
         cls.test_org_name = os.getenv("GEOSEEQ_TEST_ORG", "API Client Test Organization")
         cls.test_api_token = os.getenv("GEOSEEQ_TEST_API_TOKEN")
         if not cls.test_api_token:
-            raise ValueError("GEOSEEQ_TEST_API_TOKEN environment variable must be set")
+            pytest.skip(
+                "GeoSeeq integration tests require GEOSEEQ_TEST_API_TOKEN", allow_module_level=True
+            )
 
     def setUp(self):
         # Set up test environment

--- a/tests/test_upload_cli.py
+++ b/tests/test_upload_cli.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import unittest
+import pytest
 from pathlib import Path
 from click.testing import CliRunner
 from geoseeq.knex import Knex
@@ -14,7 +15,9 @@ class TestUploadCLI(unittest.TestCase):
         cls.test_org_name = os.getenv("GEOSEEQ_TEST_ORG", "API Client Test Organization")
         cls.test_api_token = os.getenv("GEOSEEQ_TEST_API_TOKEN")
         if not cls.test_api_token:
-            raise ValueError("GEOSEEQ_TEST_API_TOKEN environment variable must be set")
+            pytest.skip(
+                "GeoSeeq integration tests require GEOSEEQ_TEST_API_TOKEN", allow_module_level=True
+            )
 
     def setUp(self):
         # Set up test environment

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,25 @@
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from geoseeq.result.utils import check_json_serialization, md5_checksum
+from geoseeq.remote_object import RemoteObjectError
+
+
+def test_check_json_serialization_passes():
+    data = {"a": [1, 2, {"b": 3}]}
+    check_json_serialization(data)  # should not raise
+
+
+def test_check_json_serialization_fails():
+    with pytest.raises(RemoteObjectError):
+        check_json_serialization({"a": (1, 2)})
+
+
+def test_md5_checksum(tmp_path):
+    file_path = tmp_path / "file.txt"
+    content = b"hello world"
+    file_path.write_bytes(content)
+    assert md5_checksum(str(file_path)) == md5_checksum(str(file_path))


### PR DESCRIPTION
## Summary
- restore original integration tests
- skip integration tests unless GEOSEEQ_TEST_API_TOKEN is set
- keep additional unit tests and GitHub Actions workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a07e90c08832e9d736d403146649f