### PR TITLE
Add PyPI deployment workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,8 +9,10 @@
 name: Upload Python Package
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -19,7 +21,7 @@ jobs:
   deploy:
 
     runs-on: ubuntu-latest
-    
+
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
@@ -35,6 +37,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install build
     - name: Build package
-      run: python setup.py install
+      run: python -m build
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@v1.8.10
+      with:
+        user: ${{ secrets.PYPI_USERNAME }}
+        password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
## Summary
- trigger publishing on new version tags or manual dispatch
- build with `python -m build`
- publish using secrets `PYPI_USERNAME` and `PYPI_PASSWORD`

## Testing
- `pre-commit run --files .github/workflows/python-publish.yml`
- `pytest -q`
- `pytest --cov=geoseeq`

------
https://chatgpt.com/codex/tasks/task_e_685bf7d81414832e8e86419b9b282c9e