### PR TITLE
Allow manual PyPI deployment

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -11,6 +11,7 @@ name: Upload Python Package
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -19,7 +20,7 @@ jobs:
   deploy:
 
     runs-on: ubuntu-latest
-    
+
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write


### PR DESCRIPTION
## Summary
- enable `workflow_dispatch` on python-publish workflow so releases can be triggered manually

## Testing
- `pre-commit run --files .github/workflows/python-publish.yml`
- `pytest`
- `pytest --cov=geoseeq`


------
https://chatgpt.com/codex/tasks/task_e_6862f4d7fa28832e82a52e933633fd19