### PR TITLE
Add PacBio read type and document name mapping option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $ geoseeq download files --extension fastq.gz "GeoSeeq/Example CLI Project"
 
 GeoSeeq can automatically group fastq files into samples according to their
 sample name, read number, and lane number. It supports paired end, single end,
-and nanopore reads.
+nanopore, and pacbio reads.
 
 Assume you have data from a single ended sequencing run stored as fastq files:
  - Sample1_L1_R1.fastq.gz
@@ -90,6 +90,12 @@ Uploading Sample: Sample1
 GeoSeeq will automatically create a new sample named `Sample1` if it does not already exist.
 
 This command would upload data [to this project.](https://portal.geoseeq.com/sample-groups/ed59b913-91ec-489b-a1b9-4ea137a6e5cf/samples). Since only organization members can upload data, you will need to replace `GeoSeeq` with your organization name.
+
+To rename samples on the fly, provide a CSV file with current and new names using the `--name-map` option:
+
+```
+$ geoseeq upload reads --name-map sample_map.csv current_name new_name "GeoSeeq/Example CLI Project" fastq_files.txt
+```
 
 Note: You will need to have an API token set to use this command (see above)
 

--- a/docs/uploading_data_examples.md
+++ b/docs/uploading_data_examples.md
@@ -16,11 +16,11 @@ $ export GEOSEEQ_API_TOKEN=<your token from the geoseeq app>
 
 ## Uploading sequencing data
 
-GeoSeeq can automatically group fastq files into samples according to their 
+GeoSeeq can automatically group fastq files into samples according to their
 sample name, read number, and lane number. It supports paired end, single end,
-and nanopore reads.
+nanopore, and pacbio reads.
 
-Assume you have data from a single ended sequencing run stored as fastq files: 
+Assume you have data from a single ended sequencing run stored as fastq files:
  - Sample1_L1_R1.fastq.gz
  - Sample1_L1_R2.fastq.gz
  - Sample1_L2_R1.fastq.gz
@@ -47,13 +47,20 @@ Uploading Sample: Sample1
 
 GeoSeeq will automatically create a new sample named `Sample1` if it does not already exist.
 
+To rename samples during upload, provide a CSV with current and new names
+using `--name-map`:
+
+```
+$ geoseeq upload reads --name-map sample_map.csv current_name new_name "Example GeoSeeq Org/Example CLI Project" fastq_files.txt
+```
+
 Note: You will need to have an API token set to use this command (see above)
 
 ### Linking reads from S3, Wasabi, FTP, Azure, and other cloud storage services
 
 GeoSeeq allows you to link files stored on other cloud storage services without moving the files.
 
-Assume you have data from a single ended sequencing run stored as fastq files on an s3 bucket: 
+Assume you have data from a single ended sequencing run stored as fastq files on an s3 bucket:
  - `https://s3.wasabisys.com/mybucketname/Sample1_L1_R1.fastq.gz`
  - `https://s3.wasabisys.com/mybucketname/Sample1_L1_R2.fastq.gz`
  - `https://s3.wasabisys.com/mybucketname/Sample1_L2_R1.fastq.gz`

--- a/geoseeq/cli/constants.py
+++ b/geoseeq/cli/constants.py
@@ -1,11 +1,11 @@
 SINGLE_END="short_read::single_end"
 PAIRED_END="short_read::paired_end"
 NANOPORE="long_read::nanopore"
+PACBIO="long_read::pacbio"
 
 READ_MODULE_NAMES = [
     SINGLE_END,
     PAIRED_END,
     NANOPORE,
+    PACBIO,
 ]
-
-

--- a/geoseeq/cli/main.py
+++ b/geoseeq/cli/main.py
@@ -55,7 +55,7 @@ def version():
     Use of this tool implies acceptance of the GeoSeeq End User License Agreement.
     Run `geoseeq eula show` to view the EULA.
     """
-    click.echo("0.7.3dev0")  # remember to update pyproject.toml
+    click.echo("0.7.4")  # remember to update pyproject.toml
 
 
 @main.group("advanced")

--- a/geoseeq/cli/upload/upload_reads.py
+++ b/geoseeq/cli/upload/upload_reads.py
@@ -1,9 +1,10 @@
+# pylint: disable=line-too-long
 import logging
 import click
 import requests
 from os.path import basename
 import pandas as pd
-from multiprocessing import Pool, current_process
+from multiprocessing import current_process
 
 from geoseeq.cli.constants import *
 from geoseeq.cli.shared_params import (
@@ -46,10 +47,10 @@ def _upload_one_file(args):
 
 def _get_regex(knex, filepaths, module_name, lib, regex):
     """Return a regex that will group the files into samples
-    
+
     Tell the user how many files did could not be matched using the regex.
     """
-    seq_length, seq_type = module_name.split('::')[:2]
+    _, seq_type = module_name.split('::')[:2]
     args = {
         'filenames': list(filepaths.keys()),
         'sequence_type': seq_type,
@@ -181,7 +182,13 @@ def flatten_list_of_bams(filepaths):
 @private_option
 @link_option
 @no_new_versions_option
-@click.option('--name-map', default=None, nargs=3, help="A file to use for converting names. Takes three arguments: a file name, a column name for current names, and a column name for new names.")
+@click.option(
+    '--name-map',
+    default=None,
+    nargs=3,
+    required=False,
+    help='Optional CSV and column names used to map existing names to new ones. Provide: <file> <current_name_col> <new_name_col>.'
+)
 @module_option(FASTQ_MODULE_NAMES)
 @project_id_arg
 @click.argument('fastq_files', type=click.Path(exists=True), nargs=-1)
@@ -214,15 +221,23 @@ def cli_upload_reads_wizard(state, cores, overwrite, yes, regex, private, link_t
     $ ls -1 path/to/fastq/files/*.fastq.gz > file_list.txt
     $ geoseeq upload reads --yes --overwrite "GeoSeeq/Example CLI Project" file_list.txt
 
+    \b
+    # Remap sample names using a CSV file with current and new names
+    $ geoseeq upload reads --name-map sample_map.csv current_name new_name "GeoSeeq/Example CLI Project" fastq_files.txt
+
     ---
 
+    The optional ``--name-map`` flag takes three values: a CSV filename,
+    the column containing current names and the column containing new names.
+    When provided, sample names will be translated during upload.
+
     Command Arguments:
-    
+
     [PROJECT_ID] Can be a project UUID, GeoSeeq Resource Number (GRN), or an
     organization name and project name separated by a slash.
 
     \b
-    Examples: 
+    Examples:
      - Name pair: "GeoSeeq/Example CLI Project"
      - UUID: "ed59b913-91ec-489b-a1b9-4ea137a6e5cf"
      - GRN: "grn:gs1:project:ed59b913-91ec-489b-a1b9-4ea137a6e5cf"
@@ -284,12 +299,12 @@ def cli_upload_reads_wizard(state, cores, overwrite, yes, regex, private, link_t
     ---
 
     Command Arguments:
-    
+
     [PROJECT_ID] Can be a project UUID, GeoSeeq Resource Number (GRN), or an
     organization name and project name separated by a slash.
 
     \b
-    Examples: 
+    Examples:
      - Name pair: "GeoSeeq/Example CLI Project"
      - UUID: "ed59b913-91ec-489b-a1b9-4ea137a6e5cf"
      - GRN: "grn:gs1:project:ed59b913-91ec-489b-a1b9-4ea137a6e5cf"
@@ -303,4 +318,14 @@ def cli_upload_reads_wizard(state, cores, overwrite, yes, regex, private, link_t
     # filepaths = {basename(line): line for line in flatten_list_of_bams(files)}
     # click.echo(f'Found {len(filepaths)} files to upload.', err=True)
     # groups = _group_files(knex, filepaths, 'bam::bam', regex, yes)
-    # _do_upload(groups, 'bam::bam', link_type, proj, filepaths, overwrite, no_new_versions, cores, state)
+    # _do_upload(
+    #     groups,
+    #     'bam::bam',
+    #     link_type,
+    #     proj,
+    #     filepaths,
+    #     overwrite,
+    #     no_new_versions,
+    #     cores,
+    #     state,
+    # )

--- a/geoseeq/constants.py
+++ b/geoseeq/constants.py
@@ -7,6 +7,7 @@ FASTQ_MODULE_NAMES = [
     'short_read::paired_end',
     'short_read::single_end',
     'long_read::nanopore',
+    'long_read::pacbio',
     'raw::raw_reads',
     'genome::fasta',
 ]
@@ -16,4 +17,12 @@ CONFIG_FOLDER = environ.get("XDG_CONFIG_HOME", join(environ["HOME"], ".config"))
 CONFIG_DIR = environ.get("GEOSEEQ_CONFIG_DIR", join(CONFIG_FOLDER, "geoseeq"))
 PROFILES_PATH = join(CONFIG_DIR, "profiles.json")
 
-OBJECT_TYPE_STR = Literal['org', 'project', 'sample', 'sample_result_folder', 'project_result_folder', 'sample_result_file', 'project_result_file']
+OBJECT_TYPE_STR = Literal[
+    'org',
+    'project',
+    'sample',
+    'sample_result_folder',
+    'project_result_folder',
+    'sample_result_file',
+    'project_result_file',
+]

--- a/geoseeq/sample.py
+++ b/geoseeq/sample.py
@@ -1,6 +1,6 @@
 import urllib
 from .remote_object import RemoteObject
-from .result import SampleResultFile, SampleResultFolder
+from .result import SampleResultFolder
 
 
 class Sample(RemoteObject):
@@ -166,12 +166,14 @@ class Sample(RemoteObject):
             "short_read::paired_end"
             "short_read::single_end"
             "long_read::nanopore"
+            "long_read::pacbio"
         """
         if preference_order is None:
             preference_order = [
                 "short_read::paired_end",
                 "short_read::single_end",
                 "long_read::nanopore",
+                "long_read::pacbio",
             ]
         all_fastqs = self.get_all_fastqs()
         for read_type in preference_order:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geoseeq"
-version = "0.7.3dev4"
+version = "0.7.4"
 authors = [
   { name="David C. Danko", email="dcdanko@biotia.io" },
 ]

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,8 @@ import setuptools
 
 setuptools.setup(
     name='geoseeq',
-    version='0.5.6a7',  # DEPRECATED see pyproject.toml remember to update version string in CLI as well
+    version='0.7.4',  # DEPRECATED see pyproject.toml
+    # remember to update version string in CLI as well
     author="David C. Danko",
     author_email='dcdanko@biotia.io',
     description=open('README.md').read(),


### PR DESCRIPTION
## Summary
- support `long_read::pacbio` for read uploads and retrieval
- document optional `--name-map` parameter in CLI and docs
- bump version to 0.7.4 for release preparation

## Testing
- `pre-commit run --files README.md docs/uploading_data_examples.md geoseeq/cli/constants.py geoseeq/cli/main.py geoseeq/cli/upload/upload_reads.py geoseeq/constants.py geoseeq/sample.py pyproject.toml setup.py`
- `pytest`
- `pytest --cov=geoseeq`


------
https://chatgpt.com/codex/tasks/task_b_68c067f7f3bc832b8885ab5db5d0c680