### PR TITLE
Fix long read field naming when uploading

### DIFF
--- a/geoseeq/result/bioinfo.py
+++ b/geoseeq/result/bioinfo.py
@@ -7,38 +7,55 @@ class SampleBioInfoFolder:
     @property
     def is_fastq(self):
         return self.module_name in FASTQ_MODULE_NAMES
-    
+
     @property
     def is_short_read(self):
         return self.module_name.startswith('short_read')
-    
+
     @property
     def is_paired_end(self):
         return self.module_name.endswith('paired_end')
-    
+
     def read_file(self, read_id='read_1::lane_1'):
         assert self.is_fastq
-        if 'read_2' in read_id: # paired end
+        if 'read_2' in read_id:  # paired end
             assert self.is_paired_end
-        file_name = f'{self.module_name}::{read_id}'
+
+        module_parts = self.module_name.split('::')
+        module_prefix = module_parts[0]
+        module_suffix = module_parts[1] if len(module_parts) > 1 else None
+
+        if read_id.startswith(f'{self.module_name}::'):
+            file_name = read_id
+        elif module_suffix and read_id.startswith(f'{module_suffix}::'):
+            file_name = f'{module_prefix}::{read_id}'
+        else:
+            file_name = f'{self.module_name}::{read_id}'
+
         result_file = self.result_file(file_name)
         return result_file
-    
+
     def read_1(self, lane_id='lane_1'):
         assert self.is_fastq
         file_name = f'{self.module_name}::read_1::{lane_id}'
         result_file = self.result_file(file_name)
         return result_file
-    
+
     def read_2(self, lane_id='lane_1'):
         assert self.is_fastq
         assert self.is_paired_end
         file_name = f'{self.module_name}::read_2::{lane_id}'
         result_file = self.result_file(file_name)
         return result_file
-    
+
     @classmethod
-    def fastq_folder(cls, sample, read_length='short_read', paired_end=False, long_read_type='nanopore'):
+    def fastq_folder(
+        cls,
+        sample,
+        read_length='short_read',
+        paired_end=False,
+        long_read_type='nanopore',
+    ):
         if read_length == 'short_read':
             if paired_end:
                 module_name = 'short_read::paired_end'
@@ -49,4 +66,3 @@ class SampleBioInfoFolder:
         else:
             raise ValueError(f'Invalid read_length: {read_length}')
         return sample.result_folder(module_name)
-        


### PR DESCRIPTION
## Summary
- adjust SampleBioInfoFolder.read_file to keep incoming field identifiers intact
- reformat fastq_folder signature for lint compliance

## Testing
- pre-commit run --files geoseeq/result/bioinfo.py
- pytest
- pytest --cov=geoseeq

------
https://chatgpt.com/codex/tasks/task_b_68ca6bf1fdb083298c815b518a6ba929