### PR TITLE
Fix name map handling for read uploads

### DIFF
--- a/geoseeq/cli/upload/upload_reads.py
+++ b/geoseeq/cli/upload/upload_reads.py
@@ -70,10 +70,11 @@ def _get_regex(knex, filepaths, module_name, lib, regex):
 
 def _group_files(knex, filepaths, module_name, regex, yes, name_map):
     """Group the files into samples, confirm, and return the groups."""
+    name_map_lookup = None
     if name_map is not None:
         name_map_filename, cur_col, new_col = name_map
-        name_map = pd.read_csv(name_map_filename)[[cur_col, new_col]]
-        name_map = name_map.set_index(cur_col).to_dict()
+        name_map_lookup = pd.read_csv(name_map_filename)[[cur_col, new_col]]
+        name_map_lookup = name_map_lookup.set_index(cur_col)[new_col].to_dict()
     seq_length, seq_type = module_name.split('::')[:2]
     groups = knex.post('bulk_upload/group_files', json={
         'filenames': list(filepaths.keys()),
@@ -82,8 +83,8 @@ def _group_files(knex, filepaths, module_name, regex, yes, name_map):
     })
     for group in groups:
         sample_name = group["sample_name"]
-        if name_map:
-            sample_name = name_map.get(sample_name, sample_name)
+        if name_map_lookup:
+            sample_name = name_map_lookup.get(sample_name, sample_name)
             group["sample_name"] = sample_name
         click.echo(f'sample_name: {sample_name}', err=True)
         click.echo(f'  module_name: {module_name}', err=True)

--- a/tests/test_upload_reads_unit.py
+++ b/tests/test_upload_reads_unit.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+from geoseeq.cli.upload.upload_reads import _group_files
+
+
+class DummyKnex:
+    def __init__(self, groups):
+        self.groups = groups
+        self.calls = []
+
+    def post(self, endpoint, json):
+        self.calls.append((endpoint, json))
+        if endpoint == "bulk_upload/group_files":
+            return self.groups
+        raise AssertionError(f"Unexpected endpoint {endpoint}")
+
+
+def test_group_files_applies_name_map(tmp_path: Path):
+    name_map_file = tmp_path / "name_map.csv"
+    name_map_file.write_text("current,new\nold_name,new_name\n")
+
+    groups = [
+        {"sample_name": "old_name", "fields": {"R1": "old_name_R1.fastq"}},
+    ]
+    knex = DummyKnex(groups)
+
+    filepaths = {"old_name_R1.fastq": "/tmp/old_name_R1.fastq"}
+
+    updated_groups = _group_files(
+        knex,
+        filepaths,
+        "short_read::single_end",
+        regex=r"(?P<sample_name>.+)",
+        yes=True,
+        name_map=(name_map_file, "current", "new"),
+    )
+
+    assert updated_groups[0]["sample_name"] == "new_name"
+    # Ensure the grouping endpoint was called using the provided paths.
+    assert knex.calls[0][0] == "bulk_upload/group_files"
+    assert filepaths.keys() == set(knex.calls[0][1]["filenames"])


### PR DESCRIPTION
## Summary
- ensure grouped samples use a direct name-map lookup without unrelated formatting changes
- retain the unit test covering name-map usage during grouping

## Testing
- pytest -p no:cov --override-ini addopts='' tests/test_upload_reads_unit.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6922e5592ea88329b5108e154d2a0082)